### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -126,4 +126,4 @@ echo "Running command: '$command' as '$USERNAME' in '$APP_ENV' mode"
 exec 1>&3 2>&4
 exec 3>&- 4>&-
 
-exec sudo -E -u "$USERNAME" $command
+exec sudo -E -u "$USERNAME" HOME=/app $command


### PR DESCRIPTION
`sudo -E` was replacing `appuser`'s `$HOME` environment variable of `/app` with `/root` causing permission issues when selenium tried to write to `~/.cache/selenium`. This fixes [issue #130](https://github.com/calibrain/calibre-web-automated-book-downloader/issues/130) by allowing Driver from seleniumbase to successfully return instead of timing out on line 172 in `cloudflare_bypasser.py`.